### PR TITLE
Use JsConfigScope to prevent global EmitCamelCaseNames from causing invalid raw posts to Seq.

### DIFF
--- a/src/ServiceStack.Seq.RequestLogsFeature/SeqRequestLogger.cs
+++ b/src/ServiceStack.Seq.RequestLogsFeature/SeqRequestLogger.cs
@@ -7,6 +7,7 @@
     using System.Threading;
 
     using ServiceStack.Web;
+    using ServiceStack.Text;
 
     public class SeqRequestLogger : IRequestLogger
     {
@@ -50,10 +51,13 @@
             // TODO inefficient as uses 1 event : 1 http post to seq
             // replace with something to buffer/queue and  
             // batch entries for posting
-            "{0}/api/events/raw".Fmt(seqUrl)
-                .PostJsonToUrlAsync(
-                    new SeqLogRequest(entry),
-                    webRequest => webRequest.Headers.Add("X-Seq-ApiKey", apiKey));
+            using (var scope = JsConfig.With(emitCamelCaseNames: false))
+            {
+                "{0}/api/events/raw".Fmt(seqUrl)
+                    .PostJsonToUrlAsync(
+                        new SeqLogRequest(entry),
+                        webRequest => webRequest.Headers.Add("X-Seq-ApiKey", apiKey));
+            }
         }
 
         protected SeqRequestLogEntry CreateEntry(

--- a/src/ServiceStack.Seq.RequestLogsFeature/ServiceStack.Seq.RequestLogsFeature.csproj
+++ b/src/ServiceStack.Seq.RequestLogsFeature/ServiceStack.Seq.RequestLogsFeature.csproj
@@ -31,36 +31,36 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ServiceStack, Version=4.0.46.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.4.0.46\lib\net40\ServiceStack.dll</HintPath>
+    <Reference Include="ServiceStack, Version=4.0.50.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.4.0.50\lib\net40\ServiceStack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.0.46.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Client.4.0.46\lib\net40\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=4.0.50.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Client.4.0.50\lib\net40\ServiceStack.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=4.0.46.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Common.4.0.46\lib\net40\ServiceStack.Common.dll</HintPath>
+    <Reference Include="ServiceStack.Common, Version=4.0.50.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Common.4.0.50\lib\net40\ServiceStack.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Interfaces.4.0.46\lib\portable-wp80+sl5+net40+win8+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
+      <HintPath>..\..\packages\ServiceStack.Interfaces.4.0.50\lib\portable-wp80+sl5+net40+win8+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.OrmLite, Version=4.0.46.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.OrmLite.4.0.46\lib\net45\ServiceStack.OrmLite.dll</HintPath>
+    <Reference Include="ServiceStack.OrmLite, Version=4.0.50.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.OrmLite.4.0.50\lib\net45\ServiceStack.OrmLite.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.OrmLite.SqlServer, Version=4.0.46.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.OrmLite.SqlServer.4.0.46\lib\net45\ServiceStack.OrmLite.SqlServer.dll</HintPath>
+    <Reference Include="ServiceStack.OrmLite.SqlServer, Version=4.0.50.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.OrmLite.SqlServer.4.0.50\lib\net45\ServiceStack.OrmLite.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Redis, Version=4.0.46.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Redis.4.0.46\lib\net40\ServiceStack.Redis.dll</HintPath>
+    <Reference Include="ServiceStack.Redis, Version=4.0.50.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Redis.4.0.50\lib\net40\ServiceStack.Redis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.0.46.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Text.4.0.46\lib\net40\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=4.0.50.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Text.4.0.50\lib\net40\ServiceStack.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -78,7 +78,9 @@
     <Compile Include="SeqRequestLogger.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="ServiceStack.Seq.RequestLogsFeature.nuspec">
       <SubType>Designer</SubType>
     </None>

--- a/src/ServiceStack.Seq.RequestLogsFeature/packages.config
+++ b/src/ServiceStack.Seq.RequestLogsFeature/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ServiceStack" version="4.0.46" targetFramework="net45" />
-  <package id="ServiceStack.Client" version="4.0.46" targetFramework="net45" />
-  <package id="ServiceStack.Common" version="4.0.46" targetFramework="net45" />
-  <package id="ServiceStack.Interfaces" version="4.0.46" targetFramework="net45" />
-  <package id="ServiceStack.OrmLite" version="4.0.46" targetFramework="net45" />
-  <package id="ServiceStack.OrmLite.SqlServer" version="4.0.46" targetFramework="net45" />
-  <package id="ServiceStack.Redis" version="4.0.46" targetFramework="net45" />
-  <package id="ServiceStack.Text" version="4.0.46" targetFramework="net45" />
+  <package id="ServiceStack" version="4.0.50" targetFramework="net45" />
+  <package id="ServiceStack.Client" version="4.0.50" targetFramework="net45" />
+  <package id="ServiceStack.Common" version="4.0.50" targetFramework="net45" />
+  <package id="ServiceStack.Interfaces" version="4.0.50" targetFramework="net45" />
+  <package id="ServiceStack.OrmLite" version="4.0.50" targetFramework="net45" />
+  <package id="ServiceStack.OrmLite.SqlServer" version="4.0.50" targetFramework="net45" />
+  <package id="ServiceStack.Redis" version="4.0.50" targetFramework="net45" />
+  <package id="ServiceStack.Text" version="4.0.50" targetFramework="net45" />
 </packages>

--- a/test/ConsoleDemo/ConsoleDemo.csproj
+++ b/test/ConsoleDemo/ConsoleDemo.csproj
@@ -34,36 +34,36 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ServiceStack, Version=4.0.46.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.4.0.46\lib\net40\ServiceStack.dll</HintPath>
+    <Reference Include="ServiceStack, Version=4.0.50.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.4.0.50\lib\net40\ServiceStack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.0.46.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Client.4.0.46\lib\net40\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=4.0.50.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Client.4.0.50\lib\net40\ServiceStack.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=4.0.46.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Common.4.0.46\lib\net40\ServiceStack.Common.dll</HintPath>
+    <Reference Include="ServiceStack.Common, Version=4.0.50.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Common.4.0.50\lib\net40\ServiceStack.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Interfaces.4.0.46\lib\portable-wp80+sl5+net40+win8+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
+      <HintPath>..\..\packages\ServiceStack.Interfaces.4.0.50\lib\portable-wp80+sl5+net40+win8+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.OrmLite, Version=4.0.46.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.OrmLite.4.0.46\lib\net45\ServiceStack.OrmLite.dll</HintPath>
+    <Reference Include="ServiceStack.OrmLite, Version=4.0.50.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.OrmLite.4.0.50\lib\net45\ServiceStack.OrmLite.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.OrmLite.SqlServer, Version=4.0.46.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.OrmLite.SqlServer.4.0.46\lib\net45\ServiceStack.OrmLite.SqlServer.dll</HintPath>
+    <Reference Include="ServiceStack.OrmLite.SqlServer, Version=4.0.50.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.OrmLite.SqlServer.4.0.50\lib\net45\ServiceStack.OrmLite.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Redis, Version=4.0.46.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Redis.4.0.46\lib\net40\ServiceStack.Redis.dll</HintPath>
+    <Reference Include="ServiceStack.Redis, Version=4.0.50.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Redis.4.0.50\lib\net40\ServiceStack.Redis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.0.46.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Text.4.0.46\lib\net40\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=4.0.50.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Text.4.0.50\lib\net40\ServiceStack.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/ConsoleDemo/packages.config
+++ b/test/ConsoleDemo/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ServiceStack" version="4.0.46" targetFramework="net45" />
-  <package id="ServiceStack.Client" version="4.0.46" targetFramework="net45" />
-  <package id="ServiceStack.Common" version="4.0.46" targetFramework="net45" />
-  <package id="ServiceStack.Interfaces" version="4.0.46" targetFramework="net45" />
-  <package id="ServiceStack.OrmLite" version="4.0.46" targetFramework="net45" />
-  <package id="ServiceStack.OrmLite.SqlServer" version="4.0.46" targetFramework="net45" />
-  <package id="ServiceStack.Redis" version="4.0.46" targetFramework="net45" />
-  <package id="ServiceStack.Text" version="4.0.46" targetFramework="net45" />
+  <package id="ServiceStack" version="4.0.50" targetFramework="net45" />
+  <package id="ServiceStack.Client" version="4.0.50" targetFramework="net45" />
+  <package id="ServiceStack.Common" version="4.0.50" targetFramework="net45" />
+  <package id="ServiceStack.Interfaces" version="4.0.50" targetFramework="net45" />
+  <package id="ServiceStack.OrmLite" version="4.0.50" targetFramework="net45" />
+  <package id="ServiceStack.OrmLite.SqlServer" version="4.0.50" targetFramework="net45" />
+  <package id="ServiceStack.Redis" version="4.0.50" targetFramework="net45" />
+  <package id="ServiceStack.Text" version="4.0.50" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Upgrade to 4.0.50. Force JsConfig Scope to not mess with seralized casing in case has global EmitCamelCaseNames=true
