### PR TITLE
Guard against reading properties from disposed request

### DIFF
--- a/src/ServiceStack.Seq.RequestLogsFeature/SeqRequestLogger.cs
+++ b/src/ServiceStack.Seq.RequestLogsFeature/SeqRequestLogger.cs
@@ -163,7 +163,7 @@ namespace ServiceStack.Seq.RequestLogsFeature
             {
                 if (EnableResponseTracking)
                 {
-                    requestLogEntry.Properties.Add("ResponseDto", request?.Response?.Dto);
+                    requestLogEntry.Properties.Add("ResponseDto", response);
                 }
             }
             else if (EnableErrorTracking)


### PR DESCRIPTION
[RequestLogsFeature with CacheResponse attribute](https://forums.servicestack.net/t/requestlogsfeature-with-cacheresponse-attribute/3099)