### PR TITLE
Get IAppSettings in ctor rather than `Register()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Once you have it installed, you can check it is running locally on the default p
 
 # Quick Start
 
-In your `AppHost` class `Configure` method, add the plugin. By default configuration values are read from the registered `IAppSettings` instance. Alternatively all configuration options are exposed as public properties of the feature class.
+In your `AppHost` class `Configure` method, add the plugin. By default configuration values are read from the registered `IAppSettings` instance. By default this will be an instance of `AppSettings`, if an alternative implementation of `IAppSettings` is to be used it must be registered prior to this plugin being registered.
+Alternatively all configuration options are exposed as public properties of the feature class.
 
 ```csharp
 public override void Configure(Container container)

--- a/ServiceStack.Seq.RequestLogsFeature.Tests/SeqRequestLogAppHost.cs
+++ b/ServiceStack.Seq.RequestLogsFeature.Tests/SeqRequestLogAppHost.cs
@@ -2,14 +2,18 @@ namespace ServiceStack.Seq.RequestLogsFeature.Tests
 {
     using System;
     using System.Collections.Generic;
-
+    using Configuration;
+    using FakeItEasy;
     using Funq;
 
     using ServiceStack.Web;
-    
+    using static FakeItEasy.A;
+
     public class SeqRequestLogAppHost : AppSelfHostBase
     {
         public readonly string BaseUrl = "http://localhost:1337/";
+        private const string Url = "http://8.8.8.8:1234";
+        public readonly IAppSettings Settings = Fake<IAppSettings>();
 
         private string httpLocalhost  = "http://localhost:5341";
 
@@ -17,12 +21,15 @@ namespace ServiceStack.Seq.RequestLogsFeature.Tests
 
         public SeqRequestLogAppHost() : base("DemoService", typeof(DemoService).Assembly)
         {
+            CallTo(() => Settings.GetString(ConfigKeys.SeqUrl)).Returns(Url);
             CustomLogs = new List<CustomLog>();
             this.Init().Start(BaseUrl);
         }
 
         public override void Configure(Container container)
         {
+            AppSettings = Settings;
+
             Plugins.Add(
                 new SeqRequestLogsFeature(
                     new SeqRequestLogsSettings(httpLocalhost)

--- a/ServiceStack.Seq.RequestLogsFeature.Tests/SeqRequestLogsFeatureTests.cs
+++ b/ServiceStack.Seq.RequestLogsFeature.Tests/SeqRequestLogsFeatureTests.cs
@@ -1,35 +1,28 @@
 ﻿namespace ServiceStack.Seq.RequestLogsFeature.Tests
 {
-    using System;
     using System.Collections.Generic;
     using Configuration;
     using FakeItEasy;
     using FluentAssertions;
-    using Web;
     using Xunit;
     using static FakeItEasy.A;
 
     [Collection("AppHost")]
-    public class SeqRequestLogsFeatureTests
+    public class SeqRequestLogsFeatureTests : IClassFixture<SeqRequestLogAppHost>
     {
-        private readonly IAppSettings settings;
-        private readonly IAppHost appHost;
         private const string Url = "http://8.8.8.8:1234";
+        private readonly SeqRequestLogAppHost fixture;
 
-        public SeqRequestLogsFeatureTests()
+        private IAppSettings settings => fixture.Settings;
+
+        public SeqRequestLogsFeatureTests(SeqRequestLogAppHost fixture)
         {
-            settings = Fake<IAppSettings>();
-
-            appHost = Fake<IAppHost>();
-            CallTo(() => appHost.PreRequestFilters).Returns(new List<Action<IRequest, IResponse>>());
-            CallTo(() => appHost.AppSettings).Returns(settings);
-            CallTo(() => settings.GetString(ConfigKeys.SeqUrl)).Returns(Url);
+            this.fixture = fixture;
         }
 
         private SeqRequestLogsFeature GetFeature()
         {
             var feature = new SeqRequestLogsFeature();
-            feature.Register(appHost);
             return feature;
         }
 

--- a/ServiceStack.Seq.RequestLogsFeature.Tests/SeqRequestLogsTests.cs
+++ b/ServiceStack.Seq.RequestLogsFeature.Tests/SeqRequestLogsTests.cs
@@ -66,12 +66,11 @@ namespace ServiceStack.Seq.RequestLogsFeature.Tests
 
         [Fact]
         [Trait("Category", "Local")]
-        public async Task GenerateLogData()
+        public void GenerateLogData()
         {
             var client = host.GetClient();
             var names = new[]{ "bob", "server", "spoon" };
 
-            var tasks = new List<Task>();
             for (var i = 0; i < 1000; i++)
             {
                 var index = 0;
@@ -79,16 +78,7 @@ namespace ServiceStack.Seq.RequestLogsFeature.Tests
                 if (i % 100 == 0) index = 1;
                 
                 var request = new Hello(names[index]);
-                tasks.Add(client.SendAsync(request));
-            }
-
-            try
-            {
-                await Task.WhenAll(tasks).ConfigureAwait(false);
-            }
-            catch (Exception)
-            {
-                // no-op. Has expected exception
+                client.SendAsync(request);
             }
         }
     }

--- a/ServiceStack.Seq.RequestLogsFeature.Tests/SeqRequestLogsTests.cs
+++ b/ServiceStack.Seq.RequestLogsFeature.Tests/SeqRequestLogsTests.cs
@@ -4,8 +4,9 @@
 namespace ServiceStack.Seq.RequestLogsFeature.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
-
+    using System.Threading.Tasks;
     using FluentAssertions;
 
     using ServiceStack.FluentValidation;
@@ -65,11 +66,12 @@ namespace ServiceStack.Seq.RequestLogsFeature.Tests
 
         [Fact]
         [Trait("Category", "Local")]
-        public void GenerateLogData()
+        public async Task GenerateLogData()
         {
             var client = host.GetClient();
             var names = new[]{ "bob", "server", "spoon" };
 
+            var tasks = new List<Task>();
             for (var i = 0; i < 1000; i++)
             {
                 var index = 0;
@@ -77,7 +79,16 @@ namespace ServiceStack.Seq.RequestLogsFeature.Tests
                 if (i % 100 == 0) index = 1;
                 
                 var request = new Hello(names[index]);
-                client.SendAsync(request);
+                tasks.Add(client.SendAsync(request));
+            }
+
+            try
+            {
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // no-op. Has expected exception
             }
         }
     }

--- a/src/ServiceStack.Seq.RequestLogsFeature/ConfigKeys.cs
+++ b/src/ServiceStack.Seq.RequestLogsFeature/ConfigKeys.cs
@@ -1,3 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 namespace ServiceStack.Seq.RequestLogsFeature
 {
     public static class ConfigKeys

--- a/test/ConsoleDemo/AppHost.cs
+++ b/test/ConsoleDemo/AppHost.cs
@@ -34,6 +34,7 @@ namespace ConsoleDemo
             Plugins.Add(new RequestCorrelationFeature());
             Plugins.Add(new SeqRequestLogsFeature
             {
+                ApiKey = "Overwrite-app-setting",
                 // add additional properties to Seq log entry.
                 AppendProperties =
                     (request, dto, response, duration) =>


### PR DESCRIPTION
Updated feature to get IAppSettings object from ctor rather than Register method as the latter was causing an error to be thrown when setting a property via object initializer as IAppSettings hadn't been set.