### PR TITLE
Added at rest path to service registration.

### DIFF
--- a/src/ServiceStack.Seq.RequestLogsFeature/SeqRequestLogConfigService.cs
+++ b/src/ServiceStack.Seq.RequestLogsFeature/SeqRequestLogConfigService.cs
@@ -7,7 +7,8 @@ namespace ServiceStack.Seq.RequestLogsFeature
     using System.Linq;
 
     using ServiceStack.Web;
-
+    
+    [Restrict(VisibilityTo = RequestAttributes.None)]
     public class SeqRequestLogConfigService : Service
     {
         public SeqRequestLogConfig Any(SeqRequestLogConfig req)

--- a/src/ServiceStack.Seq.RequestLogsFeature/SeqRequestLogsFeature.cs
+++ b/src/ServiceStack.Seq.RequestLogsFeature/SeqRequestLogsFeature.cs
@@ -121,7 +121,11 @@ namespace ServiceStack.Seq.RequestLogsFeature
             configValidator.ValidateAndThrow(this);
 
             ConfigureRequestLogger(appHost);
-            appHost.RegisterService(typeof(SeqRequestLogConfigService));
+
+            var atRestPath = "/SeqRequestLogConfig";
+
+            appHost.RegisterService(typeof(SeqRequestLogConfigService), atRestPath);
+
             if (EnableRequestBodyTracking)
             {
                 appHost.PreRequestFilters.Insert(0, (httpReq, httpRes) =>
@@ -132,7 +136,7 @@ namespace ServiceStack.Seq.RequestLogsFeature
 
             appHost.GetPlugin<MetadataFeature>()
                 .AddDebugLink(SeqUrl, "Seq Request Logs")
-                .AddPluginLink("/SeqRequestLogConfig", "Seq IRequestLogger Configuration");
+                .AddPluginLink(atRestPath.TrimStart('/'), "Seq IRequestLogger Configuration");
         }
 
         private void ConfigureRequestLogger(IAppHost appHost)


### PR DESCRIPTION
- Added at rest path to service registration (Resolves an issue where the link would not redirect to the correct url when it contains a subdirectory)..
- Removed visibility of SeqRequestLogConfigService from ServiceStack metadata (Mimics built-in ServiceStack features).