### PR TITLE
Update to latest 4.5.10 ServiceStack release

### DIFF
--- a/ServiceStack.Seq.RequestLogsFeature.Tests/ServiceStack.Seq.RequestLogsFeature.Tests.csproj
+++ b/ServiceStack.Seq.RequestLogsFeature.Tests/ServiceStack.Seq.RequestLogsFeature.Tests.csproj
@@ -42,24 +42,24 @@
       <HintPath>..\packages\FluentAssertions.4.9.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.4.0.60\lib\net40\ServiceStack.dll</HintPath>
+    <Reference Include="ServiceStack, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.4.5.10\lib\net45\ServiceStack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.4.0.60\lib\net40\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.4.5.10\lib\net45\ServiceStack.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Common.4.0.60\lib\net40\ServiceStack.Common.dll</HintPath>
+    <Reference Include="ServiceStack.Common, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Common.4.5.10\lib\net45\ServiceStack.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.4.0.60\lib\portable-wp80+sl5+net40+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Interfaces.4.5.10\lib\portable-wp80+sl5+net45+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.4.0.60\lib\net40\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.4.5.10\lib\net45\ServiceStack.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/ServiceStack.Seq.RequestLogsFeature.Tests/packages.config
+++ b/ServiceStack.Seq.RequestLogsFeature.Tests/packages.config
@@ -2,11 +2,11 @@
 <packages>
   <package id="FakeItEasy" version="2.3.1" targetFramework="net452" />
   <package id="FluentAssertions" version="4.9.0" targetFramework="net452" />
-  <package id="ServiceStack" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.Client" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.Common" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.Interfaces" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.Text" version="4.0.60" targetFramework="net452" />
+  <package id="ServiceStack" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.Client" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.Common" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.Interfaces" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.Text" version="4.5.10" targetFramework="net452" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net452" />

--- a/src/ServiceStack.Seq.RequestLogsFeature/SeqRequestLogConfigService.cs
+++ b/src/ServiceStack.Seq.RequestLogsFeature/SeqRequestLogConfigService.cs
@@ -21,7 +21,7 @@ namespace ServiceStack.Seq.RequestLogsFeature
             if (logger.RequiredRoles.Any())
             {
                 var session = GetSession();
-                if (session != null && !logger.RequiredRoles.Any(t => session.HasRole(t)))
+                if (session != null && !logger.RequiredRoles.Any(t => session.HasRole(t, base.AuthRepository)))
                 {
                     return null;
                 }

--- a/src/ServiceStack.Seq.RequestLogsFeature/ServiceStack.Seq.RequestLogsFeature.csproj
+++ b/src/ServiceStack.Seq.RequestLogsFeature/ServiceStack.Seq.RequestLogsFeature.csproj
@@ -31,36 +31,36 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ServiceStack, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.4.0.60\lib\net40\ServiceStack.dll</HintPath>
+    <Reference Include="ServiceStack, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.4.5.10\lib\net45\ServiceStack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Client.4.0.60\lib\net40\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Client.4.5.10\lib\net45\ServiceStack.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Common.4.0.60\lib\net40\ServiceStack.Common.dll</HintPath>
+    <Reference Include="ServiceStack.Common, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Common.4.5.10\lib\net45\ServiceStack.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Interfaces.4.0.60\lib\portable-wp80+sl5+net40+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
+      <HintPath>..\..\packages\ServiceStack.Interfaces.4.5.10\lib\portable-wp80+sl5+net45+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.OrmLite, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.OrmLite.4.0.60\lib\net45\ServiceStack.OrmLite.dll</HintPath>
+    <Reference Include="ServiceStack.OrmLite, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.OrmLite.4.5.10\lib\net45\ServiceStack.OrmLite.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Redis, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Redis.4.0.60\lib\net40\ServiceStack.Redis.dll</HintPath>
+    <Reference Include="ServiceStack.Redis, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Redis.4.5.10\lib\net45\ServiceStack.Redis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Server, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Server.4.0.60\lib\net45\ServiceStack.Server.dll</HintPath>
+    <Reference Include="ServiceStack.Server, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Server.4.5.10\lib\net45\ServiceStack.Server.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Text.4.0.60\lib\net40\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Text.4.5.10\lib\net45\ServiceStack.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -83,9 +83,7 @@
     <Compile Include="Validators\ConfigValidator.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
     <None Include="ServiceStack.Seq.RequestLogsFeature.nuspec">
       <SubType>Designer</SubType>
     </None>

--- a/src/ServiceStack.Seq.RequestLogsFeature/packages.config
+++ b/src/ServiceStack.Seq.RequestLogsFeature/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ServiceStack" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.Client" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.Common" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.Interfaces" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.OrmLite" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.Redis" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.Server" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.Text" version="4.0.60" targetFramework="net452" />
+  <package id="ServiceStack" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.Client" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.Common" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.Interfaces" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.OrmLite" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.Redis" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.Server" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.Text" version="4.5.10" targetFramework="net452" />
 </packages>

--- a/test/ConsoleDemo/ConsoleDemo.csproj
+++ b/test/ConsoleDemo/ConsoleDemo.csproj
@@ -40,40 +40,40 @@
       <HintPath>..\..\packages\RustFlakes.1.4.1\lib\RustFlakes.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.4.0.60\lib\net40\ServiceStack.dll</HintPath>
+    <Reference Include="ServiceStack, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.4.5.10\lib\net45\ServiceStack.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Client.4.0.60\lib\net40\ServiceStack.Client.dll</HintPath>
+    <Reference Include="ServiceStack.Client, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Client.4.5.10\lib\net45\ServiceStack.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Common.4.0.60\lib\net40\ServiceStack.Common.dll</HintPath>
+    <Reference Include="ServiceStack.Common, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Common.4.5.10\lib\net45\ServiceStack.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Interfaces.4.0.60\lib\portable-wp80+sl5+net40+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
+      <HintPath>..\..\packages\ServiceStack.Interfaces.4.5.10\lib\portable-wp80+sl5+net45+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.OrmLite, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.OrmLite.4.0.60\lib\net45\ServiceStack.OrmLite.dll</HintPath>
+    <Reference Include="ServiceStack.OrmLite, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.OrmLite.4.5.10\lib\net45\ServiceStack.OrmLite.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Redis, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Redis.4.0.60\lib\net40\ServiceStack.Redis.dll</HintPath>
+    <Reference Include="ServiceStack.Redis, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Redis.4.5.10\lib\net45\ServiceStack.Redis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="ServiceStack.Request.Correlation, Version=4.0.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\ServiceStack.Request.Correlation.4.0.5.0\lib\net452\ServiceStack.Request.Correlation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Server, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Server.4.0.60\lib\net45\ServiceStack.Server.dll</HintPath>
+    <Reference Include="ServiceStack.Server, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Server.4.5.10\lib\net45\ServiceStack.Server.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.0.60.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\ServiceStack.Text.4.0.60\lib\net40\ServiceStack.Text.dll</HintPath>
+    <Reference Include="ServiceStack.Text, Version=4.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ServiceStack.Text.4.5.10\lib\net45\ServiceStack.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/ConsoleDemo/packages.config
+++ b/test/ConsoleDemo/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="RustFlakes" version="1.4.1" targetFramework="net452" />
-  <package id="ServiceStack" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.Client" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.Common" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.Interfaces" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.OrmLite" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.Redis" version="4.0.60" targetFramework="net452" />
+  <package id="ServiceStack" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.Client" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.Common" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.Interfaces" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.OrmLite" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.Redis" version="4.5.10" targetFramework="net452" />
   <package id="ServiceStack.Request.Correlation" version="4.0.5.0" targetFramework="net452" />
-  <package id="ServiceStack.Server" version="4.0.60" targetFramework="net452" />
-  <package id="ServiceStack.Text" version="4.0.60" targetFramework="net452" />
+  <package id="ServiceStack.Server" version="4.5.10" targetFramework="net452" />
+  <package id="ServiceStack.Text" version="4.5.10" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
ServiceStack.Text.JsConfigScope ServiceStack.Text.JsConfig.With() method signature changed in this release. So failed to log any requests, but did log it's own internal error for each of these requests.